### PR TITLE
fix： 修复两个引起崩溃的bug

### DIFF
--- a/app/src/main/assets/web/help/md/updateLog.md
+++ b/app/src/main/assets/web/help/md/updateLog.md
@@ -22,6 +22,7 @@
 **2026/7/08**
 - 修复调试中data:图片字符过长造成当前Activity崩溃回退的bug
 - 增加日志球开关判断，解决 toString 全量拼接导致 OOM造成目录显示失败的问题，降低内存开销
+- 优化备份选择器架构，提高查询效率
 
 **2026/07/06**
 - 回退有关“refactor(explore-show): 重构为ViewPager+Fragment架构

--- a/app/src/main/assets/web/help/md/updateLog.md
+++ b/app/src/main/assets/web/help/md/updateLog.md
@@ -19,6 +19,10 @@
 - [链接1](https://legado.gyks.cf/)
 - [链接2](https://legado.ccccocccc.cc/index.php?i=2)
 
+**2026/7/08**
+- 修复调试中data:图片字符过长造成当前Activity崩溃回退的bug
+- 增加日志球开关判断，解决 toString 全量拼接导致 OOM造成目录显示失败的问题，降低内存开销
+
 **2026/07/06**
 - 回退有关“refactor(explore-show): 重构为ViewPager+Fragment架构
   ”的更改

--- a/app/src/main/java/io/legado/app/help/storage/BackupSelectorConfig.kt
+++ b/app/src/main/java/io/legado/app/help/storage/BackupSelectorConfig.kt
@@ -1,13 +1,16 @@
 package io.legado.app.help.storage
 
+import io.legado.app.data.repository.CoverGalleryRepository
 import io.legado.app.utils.FileUtils
 import io.legado.app.utils.GSON
 import io.legado.app.utils.fromJsonObject
-import io.legado.app.data.repository.CoverGalleryRepository
-import io.legado.app.ui.widget.components.dialog.MultiSelectItem
-import io.legado.app.ui.widget.components.dialog.MultiSelectGroup
 import splitties.init.appCtx
 
+/**
+ * 备份选择器配置。
+ *
+ * 这个文件只维护可备份项定义和用户选择结果的读写，不依赖具体 UI 组件。
+ */
 @Suppress("ConstPropertyName")
 object BackupSelectorConfig {
 
@@ -77,8 +80,20 @@ object BackupSelectorConfig {
         return selectedMap[key] ?: true
     }
 
+    fun getSelectedKeys(): Set<String> {
+        return allItems
+            .filter { isSelected(it.key) }
+            .map { it.key }
+            .toSet()
+    }
+
     fun setSelected(key: String, selected: Boolean) {
         selectedMap[key] = selected
+    }
+
+    // 供选择器弹窗在确认时一次性提交内存中的完整选择结果。
+    fun setSelectedKeys(keys: Set<String>) {
+        allItems.forEach { selectedMap[it.key] = it.key in keys }
     }
 
     fun selectAll() {
@@ -116,79 +131,5 @@ object BackupSelectorConfig {
             "其他" -> "📦"
             else -> null
         }
-    }
-
-    /**
-     * 获取带有详细信息的 MultiSelectGroup 列表
-     */
-    fun getMultiSelectGroups(): List<MultiSelectGroup> {
-        val overview = BackupInfoHelper.getBackupOverview()
-        
-        return groupItems.map { (groupName, items) ->
-            MultiSelectGroup(
-                name = groupName,
-                iconEmoji = getGroupIcon(groupName),
-                items = items.map { item ->
-                    val fileInfo = overview.items.find { it.fileName == item.fileName }
-                    val countInfo = getCountInfo(item.key)
-                    
-                    MultiSelectItem(
-                        key = item.key,
-                        title = item.title,
-                        subtitle = item.fileName,
-                        size = fileInfo?.let { BackupInfoHelper.formatSize(it.size) },
-                        rawSize = fileInfo?.size,
-                        count = countInfo,
-                        group = item.group,
-                        iconEmoji = item.iconEmoji,
-                        selected = isSelected(item.key)
-                    )
-                }
-            )
-        }
-    }
-
-    /**
-     * 计算选中项的总大小
-     */
-    fun calculateTotalSize(selectedItems: List<MultiSelectItem>): String {
-        return BackupInfoHelper.formatSize(selectedItems.sumOf { it.rawSize ?: 0L })
-    }
-
-    /**
-     * 获取带有数量和大小的 MultiSelectItem
-     */
-    fun getMultiSelectItemWithDetails(key: String): MultiSelectItem {
-        val item = allItems.find { it.key == key } ?: return MultiSelectItem(
-            key = key,
-            title = key,
-            group = "其他"
-        )
-        
-        val overview = BackupInfoHelper.getBackupOverview()
-        val fileInfo = overview.items.find { it.fileName == item.fileName }
-        
-        // 获取数量信息
-        val countInfo = getCountInfo(key)
-        
-        return MultiSelectItem(
-            key = item.key,
-            title = item.title,
-            subtitle = item.fileName,
-            size = fileInfo?.let { BackupInfoHelper.formatSize(it.size) },
-            rawSize = fileInfo?.size,
-            count = countInfo,
-            group = item.group,
-            iconEmoji = item.iconEmoji,
-            selected = isSelected(item.key)
-        )
-    }
-
-    /**
-     * 获取数据数量信息
-     */
-    private fun getCountInfo(key: String): String? {
-        val count = BackupInfoHelper.getItemCount(key)
-        return if (count > 0) "$count 个" else null
     }
 }

--- a/app/src/main/java/io/legado/app/model/Debug.kt
+++ b/app/src/main/java/io/legado/app/model/Debug.kt
@@ -40,6 +40,20 @@ object Debug {
     @SuppressLint("ConstantLocale")
     private val debugTimeFormat = SimpleDateFormat("[mm:ss.SSS]", Locale.getDefault())
     private var startTime: Long = System.currentTimeMillis()
+    private val dataUrlBase64Regex =
+        Regex("""data:([^;,\s"'<>)]*)?;base64,[A-Za-z0-9+/=_-]+""", RegexOption.IGNORE_CASE)
+
+    private fun sanitizeDebugMessage(msg: String): String {
+        if (!msg.contains("data:", ignoreCase = true) ||
+            !msg.contains("base64,", ignoreCase = true)
+        ) {
+            return msg
+        }
+        return dataUrlBase64Regex.replace(msg) {
+            val mediaType = it.groups[1]?.value?.takeIf { type -> type.isNotBlank() } ?: "unknown"
+            "data:$mediaType [base64图片字符过长省略输出], length=${it.value.length}]"
+        }
+    }
 
     /**
      * 记录日志
@@ -60,15 +74,16 @@ object Debug {
         state: Int = 1,
         category: DebugCategory? = null
     ) {
+        val safeMsg = sanitizeDebugMessage(msg)
         if (BuildConfig.DEBUG) {
-            Log.d("sourceDebug", msg)
+            Log.d("sourceDebug", safeMsg)
         }
         //调试信息始终要执行
         callback?.let {
             if ((debugSource != sourceUrl || !print)) return
-            var printMsg = msg
+            var printMsg = safeMsg
             if (isHtml) {
-                printMsg = HtmlFormatter.format(msg)
+                printMsg = HtmlFormatter.format(safeMsg)
             }
             if (showTime) {
                 val time = debugTimeFormat.format(Date(System.currentTimeMillis() - startTime))
@@ -79,7 +94,7 @@ object Debug {
 
         // 在锁外异步上报到调试事件中心，避免持锁期间启动协程
         if (DebugEventCenter.isEnabled) {
-            val capturedMsg = msg
+            val capturedMsg = safeMsg
             val capturedSourceUrl = sourceUrl
             val capturedState = state
             val capturedIsHtml = isHtml
@@ -126,10 +141,10 @@ object Debug {
         }
         }
 
-        if (isChecking && sourceUrl != null && (msg).length < 30) {
-            var printMsg = msg
+        if (isChecking && sourceUrl != null && safeMsg.length < 30) {
+            var printMsg = safeMsg
             if (isHtml) {
-                printMsg = HtmlFormatter.format(msg)
+                printMsg = HtmlFormatter.format(safeMsg)
             }
             if (showTime && debugTimeMap[sourceUrl] != null) {
                 val time =

--- a/app/src/main/java/io/legado/app/model/analyzeRule/AnalyzeRule.kt
+++ b/app/src/main/java/io/legado/app/model/analyzeRule/AnalyzeRule.kt
@@ -22,6 +22,7 @@ import io.legado.app.help.http.BackstageWebView
 import io.legado.app.help.http.CookieStore
 import io.legado.app.help.source.getShareScope
 import io.legado.app.model.Debug
+import io.legado.app.model.debug.toDebugString
 import io.legado.app.model.webBook.WebBook
 import io.legado.app.utils.GSON
 import io.legado.app.utils.GSONStrict
@@ -1030,8 +1031,9 @@ class AnalyzeRule(
     fun evalJS(jsStr: String, result: Any? = null): Any? {
         val startTime = System.currentTimeMillis()
         val containsReplace = jsStr.contains("replace")
+        val isLoggingEnabled = FlowLogRecorder.isEnabled
         
-        if (containsReplace) {
+        if (containsReplace && isLoggingEnabled) {
             FlowLogRecorder.logReplace(
                 source = source,
                 message = "执行JS替换",
@@ -1042,7 +1044,8 @@ class AnalyzeRule(
             )
         }
         
-        val jsContext = buildJsExecutionContext(result)
+        // 只在需要记录日志时才构建 jsContext，避免不必要的内存开销
+        val jsContext = if (isLoggingEnabled) buildJsExecutionContext(result) else null
         
         val bindings = buildScriptBindings { bindings ->
             bindings["java"] = this
@@ -1085,45 +1088,49 @@ class AnalyzeRule(
                 currentRuleTypeThreadLocal.set(previousRuleType)
             }
         } catch (e: Exception) {
+            if (isLoggingEnabled) {
+                val duration = System.currentTimeMillis() - startTime
+                FlowLogRecorder.logJsContext(
+                    source = source,
+                    jsCode = jsStr,
+                    context = jsContext!!,
+                    result = null,
+                    duration = duration,
+                    error = e,
+                    book = book as? Book,
+                    bookChapter = chapter,
+                    bookSource = source as? BookSource
+                )
+            }
+            throw e
+        }
+        
+        if (isLoggingEnabled) {
             val duration = System.currentTimeMillis() - startTime
             FlowLogRecorder.logJsContext(
                 source = source,
                 jsCode = jsStr,
-                context = jsContext,
-                result = null,
-                duration = duration,
-                error = e,
-                book = book as? Book,
-                bookChapter = chapter,
-                bookSource = source as? BookSource
-            )
-            throw e
-        }
-        
-        val duration = System.currentTimeMillis() - startTime
-        FlowLogRecorder.logJsContext(
-            source = source,
-            jsCode = jsStr,
-            context = jsContext,
-            result = jsResult?.toString()?.take(200),
-            duration = duration,
-            book = book as? Book,
-            bookChapter = chapter,
-            bookSource = source as? BookSource
-        )
-        
-        if (containsReplace) {
-            FlowLogRecorder.logReplace(
-                source = source,
-                message = "JS替换完成",
-                rule = jsStr.take(200),
-                result = jsResult?.toString()?.take(100),
-                originalValue = result?.toString()?.take(100),
+                context = jsContext!!,
+                result = jsResult.toDebugString(200),
                 duration = duration,
                 book = book as? Book,
                 bookChapter = chapter,
                 bookSource = source as? BookSource
             )
+            
+            if (containsReplace) {
+                FlowLogRecorder.logReplace(
+                    source = source,
+                    message = "JS替换完成",
+                    rule = jsStr.take(200),
+                    result = jsResult.toDebugString(100),
+                    originalValue = result.toDebugString(100),
+                    duration = duration,
+                    book = book as? Book,
+                    bookChapter = chapter,
+                    bookSource = source as? BookSource
+                )
+            }
         }
         
         return jsResult
@@ -1131,8 +1138,8 @@ class AnalyzeRule(
     
     private fun buildJsExecutionContext(result: Any?): io.legado.app.model.debug.JsExecutionContext {
         return io.legado.app.model.debug.JsExecutionContext(
-            result = result?.toString()?.take(200),
-            src = content?.toString()?.take(200),
+            result = result.toDebugString(200),
+            src = content.toDebugString(200),
             baseUrl = baseUrl,
             book = book?.let { baseBook ->
                 val bookEntity = baseBook as? io.legado.app.data.entities.Book

--- a/app/src/main/java/io/legado/app/model/debug/DebugLogUtils.kt
+++ b/app/src/main/java/io/legado/app/model/debug/DebugLogUtils.kt
@@ -12,6 +12,31 @@ import java.util.Date
 import java.util.Locale
 
 /**
+ * 把任意对象转为用于调试日志的简短字符串，避免对 Collection、Map 等容器直接调用 toString()
+ * 产生超大字符串导致 OOM。
+ */
+fun Any?.toDebugString(maxLength: Int = 200): String? {
+    if (this == null) return null
+    if (this is String) return take(maxLength)
+    if (this is CharSequence) return toString().take(maxLength)
+    if (this is Collection<*>) {
+        val header = "Collection(size=$size)"
+        if (isEmpty() || header.length >= maxLength) return header.take(maxLength)
+        val remaining = maxLength - header.length - 2
+        if (remaining <= 0) return header.take(maxLength)
+        val first = firstOrNull()?.toDebugString(remaining.coerceAtMost(120))
+        return "$header[$first]"
+    }
+    if (this is Array<*>) {
+        return "Array(size=$size)".take(maxLength)
+    }
+    if (this is Map<*, *>) {
+        return "Map(size=$size)".take(maxLength)
+    }
+    return toString().take(maxLength)
+}
+
+/**
  * 调试日志模块共享工具函数
  */
 object DebugLogUtils {

--- a/app/src/main/java/io/legado/app/model/debug/RuleExecutionTracker.kt
+++ b/app/src/main/java/io/legado/app/model/debug/RuleExecutionTracker.kt
@@ -48,7 +48,7 @@ class RuleExecutionTracker(
             index = stepIndex,
             ruleType = ruleType,
             ruleContent = ruleContent,
-            input = input?.toString()?.take(200)
+            input = input.toDebugString(200)
         )
     }
 
@@ -59,7 +59,7 @@ class RuleExecutionTracker(
         regexGroups: List<String>? = null
     ) {
         currentStep?.let { step ->
-            step.output = output?.toString()?.take(200)
+            step.output = output.toDebugString(200)
             step.matchCount = matchCount
             step.duration = System.currentTimeMillis() - step.startTime
             step.jsContext = jsContext

--- a/app/src/main/java/io/legado/app/ui/widget/dialog/BackupSelectorDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/widget/dialog/BackupSelectorDialog.kt
@@ -1,124 +1,102 @@
 package io.legado.app.ui.widget.dialog
 
-import androidx.compose.foundation.layout.*
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import androidx.fragment.app.viewModels
 import io.legado.app.R
-import io.legado.app.help.storage.BackupSelectorConfig
 import io.legado.app.ui.theme.pageCardContainerColor
 import io.legado.app.ui.widget.components.dialog.BaseComposeDialogFragment
 import io.legado.app.ui.widget.components.dialog.MultiSelectDialogContent
-import io.legado.app.ui.widget.components.dialog.MultiSelectGroup
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 
 /**
- * 备份选择器对话框 - Compose实现
- * 
- * 功能说明:
- * 提供一个界面让用户选择要备份的项目
- * 显示文件名、大小、数量等详细信息
+ * 备份选择器弹窗。
+ *
+ * 这个文件只负责 Compose 弹窗展示和用户事件转发，具体加载、选择和保存逻辑交给 ViewModel。
  */
 class BackupSelectorDialog : BaseComposeDialogFragment() {
+
+    private val viewModel by viewModels<BackupSelectorViewModel>()
 
     @Composable
     override fun DialogContent() {
         BackupSelectorDialogContent(
+            viewModel = viewModel,
             onDismiss = { dismiss() }
         )
     }
 }
 
-/**
- * 备份选择器对话框内容
- */
 @Composable
 fun BackupSelectorDialogContent(
+    viewModel: BackupSelectorViewModel,
     onDismiss: () -> Unit
 ) {
-    // 异步加载分组数据（含文件大小统计，涉及 I/O 操作）
-    var groups by remember { mutableStateOf<List<MultiSelectGroup>>(emptyList()) }
-    var isLoading by remember { mutableStateOf(true) }
+    // 保持 Composable 只负责渲染；加载、选择和持久化都放在 ViewModel 中处理。
+    val uiState by viewModel.uiState.collectAsState()
 
-    LaunchedEffect(Unit) {
-        withContext(Dispatchers.IO) {
-            BackupSelectorConfig.getMultiSelectGroups()
-        }.let { result ->
-            groups = result
-            isLoading = false
+    when (val state = uiState) {
+        BackupSelectorUiState.Loading -> {
+            BackupSelectorLoadingDialog(onDismiss = onDismiss)
+        }
+
+        is BackupSelectorUiState.Content -> {
+            MultiSelectDialogContent(
+                title = stringResource(R.string.backup_selector),
+                groups = state.groups,
+                selectedKeys = state.selectedKeys,
+                totalSizeCalculator = viewModel::formatTotalSize,
+                onSelectionChange = viewModel::onSelectionChange,
+                onDismiss = {
+                    viewModel.saveSelection()
+                    onDismiss()
+                },
+                onSelectAll = viewModel::selectAll,
+                onDeselectAll = viewModel::deselectAll
+            )
         }
     }
+}
 
-    // 已选中的key集合
-    var selectedKeys by remember {
-        mutableStateOf(
-            BackupSelectorConfig.allItems
-                .filter { BackupSelectorConfig.isSelected(it.key) }
-                .map { it.key }
-                .toSet()
+@Composable
+private fun BackupSelectorLoadingDialog(
+    onDismiss: () -> Unit
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(
+            dismissOnBackPress = true,
+            dismissOnClickOutside = true
         )
-    }
-
-    if (isLoading) {
-        Dialog(
-            onDismissRequest = onDismiss,
-            properties = DialogProperties(
-                dismissOnBackPress = true,
-                dismissOnClickOutside = true
-            )
+    ) {
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .wrapContentHeight(),
+            shape = MaterialTheme.shapes.large,
+            color = pageCardContainerColor()
         ) {
-            Surface(
+            Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .wrapContentHeight(),
-                shape = MaterialTheme.shapes.large,
-                color = pageCardContainerColor()
+                    .height(120.dp),
+                contentAlignment = Alignment.Center
             ) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(120.dp),
-                    contentAlignment = Alignment.Center
-                ) {
-                    CircularProgressIndicator()
-                }
+                CircularProgressIndicator()
             }
         }
-        return
     }
-
-    MultiSelectDialogContent(
-        title = stringResource(R.string.backup_selector),
-        groups = groups,
-        selectedKeys = selectedKeys,
-        totalSizeCalculator = { selectedItems ->
-            BackupSelectorConfig.calculateTotalSize(selectedItems)
-        },
-        onSelectionChange = { key, isSelected ->
-            selectedKeys = if (isSelected) {
-                selectedKeys + key
-            } else {
-                selectedKeys - key
-            }
-            BackupSelectorConfig.setSelected(key, isSelected)
-        },
-        onDismiss = {
-            BackupSelectorConfig.save()
-            onDismiss()
-        },
-        onSelectAll = {
-            BackupSelectorConfig.selectAll()
-            selectedKeys = BackupSelectorConfig.allItems.map { it.key }.toSet()
-        },
-        onDeselectAll = {
-            BackupSelectorConfig.deselectAll()
-            selectedKeys = emptySet()
-        }
-    )
 }

--- a/app/src/main/java/io/legado/app/ui/widget/dialog/BackupSelectorViewModel.kt
+++ b/app/src/main/java/io/legado/app/ui/widget/dialog/BackupSelectorViewModel.kt
@@ -1,0 +1,152 @@
+package io.legado.app.ui.widget.dialog
+
+import android.app.Application
+import androidx.lifecycle.viewModelScope
+import io.legado.app.base.BaseViewModel
+import io.legado.app.help.storage.BackupInfoHelper
+import io.legado.app.help.storage.BackupSelectorConfig
+import io.legado.app.ui.widget.components.dialog.MultiSelectGroup
+import io.legado.app.ui.widget.components.dialog.MultiSelectItem
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * 备份选择器界面状态。
+ *
+ * 这个状态只服务于弹窗展示：加载中显示进度，加载完成后提供分组数据和当前选中项。
+ */
+sealed class BackupSelectorUiState {
+    object Loading : BackupSelectorUiState()
+
+    data class Content(
+        val groups: List<MultiSelectGroup>,
+        val selectedKeys: Set<String>
+    ) : BackupSelectorUiState()
+}
+
+/**
+ * 备份选择器的 ViewModel。
+ *
+ * 负责加载备份项详情、维护弹窗内的选择状态，并在用户确认时统一写回配置。
+ */
+class BackupSelectorViewModel(application: Application) : BaseViewModel(application) {
+
+    private val _uiState = MutableStateFlow<BackupSelectorUiState>(BackupSelectorUiState.Loading)
+    val uiState: StateFlow<BackupSelectorUiState> = _uiState.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun load() {
+        // 备份概览会读取数据库数量和文件大小，必须放到 IO 线程，避免阻塞主线程。
+        viewModelScope.launch(Dispatchers.IO) {
+            _uiState.value = buildUiState()
+        }
+    }
+    /**
+     * 处理用户选择项变化事件。
+     *
+     * @param key 被选择项的键值。
+     * @param isSelected 如果为 true，则添加到选中项集合；否则从集合中移除。
+     */
+
+    fun onSelectionChange(key: String, isSelected: Boolean) {
+        updateContent { content ->
+            val selectedKeys = if (isSelected) {
+                content.selectedKeys + key
+            } else {
+                content.selectedKeys - key
+            }
+            content.copy(selectedKeys = selectedKeys)
+        }
+    }
+    /**
+     * 全选所有备份项。
+     */
+    fun selectAll() {
+        updateContent { content ->
+            content.copy(
+                selectedKeys = content.groups
+                    .flatMap { it.items }
+                    .map { it.key }
+                    .toSet()
+            )
+        }
+    }
+    /**
+     * 取消全选所有备份项。
+     */
+    fun deselectAll() {
+        updateContent { content ->
+            content.copy(selectedKeys = emptySet())
+        }
+    }
+
+    fun saveSelection() {
+        val content = _uiState.value as? BackupSelectorUiState.Content ?: return
+        // 弹窗内的勾选变化先保存在内存中，只有用户确认关闭时才写回配置文件。
+        BackupSelectorConfig.setSelectedKeys(content.selectedKeys)
+        BackupSelectorConfig.save()
+    }
+    /**
+     * 格式化选中项的总大小。
+     *
+     * @param selectedItems 选中的备份项列表。
+     * @return 格式化后的总大小字符串。
+     */
+    fun formatTotalSize(selectedItems: List<MultiSelectItem>): String {
+        return BackupInfoHelper.formatSize(selectedItems.sumOf { it.rawSize ?: 0L })
+    }
+
+    private fun updateContent(
+        block: (BackupSelectorUiState.Content) -> BackupSelectorUiState.Content
+    ) {
+        val content = _uiState.value as? BackupSelectorUiState.Content ?: return
+        _uiState.value = block(content)
+    }
+
+    private fun buildUiState(): BackupSelectorUiState.Content {
+        // 在 ViewModel 中把存储层的备份定义转换成通用多选弹窗模型，
+        // 避免 BackupSelectorConfig 反向依赖 UI 组件类。
+        val overview = BackupInfoHelper.getBackupOverview()
+        val fileInfoByName = overview.items.associateBy { it.fileName }
+        val selectedKeys = BackupSelectorConfig.getSelectedKeys()
+        val groups = BackupSelectorConfig.groupItems.map { (groupName, items) ->
+            MultiSelectGroup(
+                name = groupName,
+                iconEmoji = BackupSelectorConfig.getGroupIcon(groupName),
+                items = items.map { item ->
+                    val fileInfo = fileInfoByName[item.overviewFileName()]
+                    val countInfo = BackupInfoHelper.getItemCount(item.key)
+                        .takeIf { it > 0 }
+                        ?.let { "$it 个" }
+
+                    MultiSelectItem(
+                        key = item.key,
+                        title = item.title,
+                        subtitle = item.fileName,
+                        size = fileInfo?.let { BackupInfoHelper.formatSize(it.size) },
+                        rawSize = fileInfo?.size,
+                        count = countInfo,
+                        group = item.group,
+                        iconEmoji = item.iconEmoji,
+                        selected = item.key in selectedKeys
+                    )
+                }
+            )
+        }
+        return BackupSelectorUiState.Content(groups, selectedKeys)
+    }
+
+    private fun BackupSelectorConfig.BackupItem.overviewFileName(): String {
+        return when (key) {
+            // 选择器持久化的是 "bg"，但 BackupInfoHelper 统计时使用的是展示分组 key。
+            "backgroundImages" -> "backgroundImages"
+            else -> fileName
+        }
+    }
+}


### PR DESCRIPTION
问题：
- buildJsExecutionContext 对 Collection 类型调用 .toString().take(200)
- toString 先生成完整字符串（可能 25MB），take 才截断，OOM 在截断前发生
- 即使不开悬浮球，buildJsExecutionContext 也被调用，浪费内存

修改：
1. 新增 toDebugString() 函数，对 Collection/Array/Map 直接返回简短摘要
2. evalJS() 开头检查 FlowLogRecorder.isEnabled，条件构建 jsContext
3. 替换所有 ?.toString()?.take() 为 toDebugString()

效果：
- 开悬浮球时内存安全（从 MB 级降到百字节级）
- 不开悬浮球时零开销